### PR TITLE
Add a msgId to metadata and make logger show it

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>monasca</groupId>
     <artifactId>monasca-persister</artifactId>
-    <version>1.1.0-Release-0.1.14-FIWARE</version>
+    <version>1.0.0.1</version>
     <url>http://github.com/telefonicaid/monasca-persister</url>
     <packaging>jar</packaging>
 

--- a/java/src/main/java/monasca/persister/consumer/KafkaConsumerRunnableBasic.java
+++ b/java/src/main/java/monasca/persister/consumer/KafkaConsumerRunnableBasic.java
@@ -121,7 +121,8 @@ public class KafkaConsumerRunnableBasic<T> implements Runnable {
 
             final String msg = new String(it.next().message());
 
-            logger.debug("[{}]: {}", this.threadId, msg);
+            /* skipped: this message is the same as shown by processEnvelope() when publishing the event */
+            /* logger.debug("[{}]: {}", this.threadId, msg); */
 
             publishEvent(msg);
 

--- a/java/src/main/resources/persister-config.yml
+++ b/java/src/main/resources/persister-config.yml
@@ -126,6 +126,9 @@ logging:
       # The timezone used to format dates. HINT: USE THE DEFAULT, UTC.
       timeZone: UTC
 
+      # The format including msgId from logger's mapped diagnostic context (MDC)
+      logFormat: "%level  [%d{YYYY-MM-dd HH:mm:ss,SSS}] [msgId=%X{msgId:-N/A}] %logger: %msg%n"
+
       # Uncomment to approximately match the default log format of the python
       # Openstack components. %pid is unavoidably formatted with [brackets],
       # which are hard-coded in dropwizard's logging module.

--- a/run_maven.sh
+++ b/run_maven.sh
@@ -64,9 +64,9 @@ if [ $RUN_BUILD = "true" ]; then
 fi
 
 # Result artifact
-if [ $RC -eq 0 -a -r target/*-shaded.jar ]; then
-    ARTIFACT_JAR=$(ls -1rt target/*-shaded.jar | tail -1)
-    ARTIFACT_VER=$(awk -F'[<>]' '/version/ { print $3; exit }' pom.xml)
+ARTIFACT_JAR=$(ls -1rt target/*-shaded.jar | tail -1)
+ARTIFACT_VER=$(awk -F'[<>]' '/version/ { print $3; exit }' pom.xml)
+if [ $RC -eq 0 -a -n "$ARTIFACT_JAR" ]; then
     cp $ARTIFACT_JAR target/monasca-persister.jar
     printf "\nmonasca-persister $ARTIFACT_VER generated at target/monasca-persister.jar\n\n"
 fi


### PR DESCRIPTION
#### Reviewers

@flopezag 
#### Description

In order in increase traceability, a msgId has been added to datapoint's "meta" field and is shown in log messages
#### Testing

Verified in Monasca master.
